### PR TITLE
Homebrew and freetype

### DIFF
--- a/INSTALL.MacOSX.md
+++ b/INSTALL.MacOSX.md
@@ -13,4 +13,8 @@
 
  * Install it from source as described in INSTALL.MacOSXErlangFromSource.md
 
+## Or install Erlang and the other dependencies using the [homebrew](http://mxcl.github.com/homebrew/) package manager
+
+ * Install homebrew from http://mxcl.github.com/homebrew/
+ * `brew install erlang cmake ftgl json_spirit gtest`
 

--- a/worker/CMakeLists.txt
+++ b/worker/CMakeLists.txt
@@ -17,6 +17,7 @@ configure_file (
 include_directories("${PROJECT_BINARY_DIR}")
 include_directories("include")	
 include_directories("/usr/local/include")
+include_directories("/usr/local/include/freetype2")
 include_directories("/usr/local/inc")
 include_directories("/opt/local/include")
 include_directories("/opt/local/include/freetype2/")
@@ -40,7 +41,7 @@ target_link_libraries(run-tests ${GTEST_BOTH_LIBRARIES})
 
 set(CMAKE_CXX_FLAGS "-DHAVE_CONFIG_H")
 
-set(ALL_LIBS -L/opt/local/lib -/usr/X11R6/lib -ljson_spirit -lpthread -lfreetype -lPTKernel -lTKAdvTools -lTKBin -lTKBinL -lTKBinTObj -lTKBinXCAF -lTKBO -lTKBool -lTKBRep -lTKCAF -lTKCDF -lTKernel -lTKFeat -lTKFillet -lTKG2d -lTKG3d -lTKGeomAlgo -lTKGeomBase -lTKHLR -lTKIGES -lTKLCAF -lTKMath -lTKMesh -lTKMeshVS -lTKNIS -lTKOffset -lTKOpenGl -lTKPCAF -lTKPLCAF -lTKPrim -lTKPShape -lTKService -lTKShapeSchema -lTKShHealing -lTKStdLSchema  -lTKStdSchema -lTKSTEP -lTKSTEP209 -lTKSTEPAttr -lTKSTEPBase -lTKSTL -lTKTopAlgo -lTKV2d -lTKV3d -lTKXMesh -lTKXml -lTKXmlL -lTKXmlTObj -lTKXmlXCAF -lTKXSBase)
+set(ALL_LIBS -L/usr/local/lib -L/opt/local/lib -/usr/X11R6/lib -ljson_spirit -lpthread -lfreetype -lPTKernel -lTKAdvTools -lTKBin -lTKBinL -lTKBinTObj -lTKBinXCAF -lTKBO -lTKBool -lTKBRep -lTKCAF -lTKCDF -lTKernel -lTKFeat -lTKFillet -lTKG2d -lTKG3d -lTKGeomAlgo -lTKGeomBase -lTKHLR -lTKIGES -lTKLCAF -lTKMath -lTKMesh -lTKMeshVS -lTKNIS -lTKOffset -lTKOpenGl -lTKPCAF -lTKPLCAF -lTKPrim -lTKPShape -lTKService -lTKShapeSchema -lTKShHealing -lTKStdLSchema  -lTKStdSchema -lTKSTEP -lTKSTEP209 -lTKSTEPAttr -lTKSTEPBase -lTKSTL -lTKTopAlgo -lTKV2d -lTKV3d -lTKXMesh -lTKXml -lTKXmlL -lTKXmlTObj -lTKXmlXCAF -lTKXSBase)
 
 target_link_libraries(worker ${ALL_LIBS})
 target_link_libraries(run-tests ${ALL_LIBS})

--- a/worker/CMakeLists.txt
+++ b/worker/CMakeLists.txt
@@ -21,6 +21,8 @@ include_directories("/usr/local/inc")
 include_directories("/opt/local/include")
 include_directories("/opt/local/include/freetype2/")
 include_directories("/usr/include/freetype2/")
+include_directories("/usr/X11R6/include")
+include_directories("/usr/X11R6/include/freetype2")
 
 set(ALL_CLASSES src/worker.cxx src/Builder.cxx src/Transform.cxx src/Util.cxx src/Tesselate.cxx src/base64.cpp)
 
@@ -38,7 +40,7 @@ target_link_libraries(run-tests ${GTEST_BOTH_LIBRARIES})
 
 set(CMAKE_CXX_FLAGS "-DHAVE_CONFIG_H")
 
-set(ALL_LIBS -L/opt/local/lib -ljson_spirit -lpthread -lfreetype -lPTKernel -lTKAdvTools -lTKBin -lTKBinL -lTKBinTObj -lTKBinXCAF -lTKBO -lTKBool -lTKBRep -lTKCAF -lTKCDF -lTKernel -lTKFeat -lTKFillet -lTKG2d -lTKG3d -lTKGeomAlgo -lTKGeomBase -lTKHLR -lTKIGES -lTKLCAF -lTKMath -lTKMesh -lTKMeshVS -lTKNIS -lTKOffset -lTKOpenGl -lTKPCAF -lTKPLCAF -lTKPrim -lTKPShape -lTKService -lTKShapeSchema -lTKShHealing -lTKStdLSchema  -lTKStdSchema -lTKSTEP -lTKSTEP209 -lTKSTEPAttr -lTKSTEPBase -lTKSTL -lTKTopAlgo -lTKV2d -lTKV3d -lTKXMesh -lTKXml -lTKXmlL -lTKXmlTObj -lTKXmlXCAF -lTKXSBase)
+set(ALL_LIBS -L/opt/local/lib -/usr/X11R6/lib -ljson_spirit -lpthread -lfreetype -lPTKernel -lTKAdvTools -lTKBin -lTKBinL -lTKBinTObj -lTKBinXCAF -lTKBO -lTKBool -lTKBRep -lTKCAF -lTKCDF -lTKernel -lTKFeat -lTKFillet -lTKG2d -lTKG3d -lTKGeomAlgo -lTKGeomBase -lTKHLR -lTKIGES -lTKLCAF -lTKMath -lTKMesh -lTKMeshVS -lTKNIS -lTKOffset -lTKOpenGl -lTKPCAF -lTKPLCAF -lTKPrim -lTKPShape -lTKService -lTKShapeSchema -lTKShHealing -lTKStdLSchema  -lTKStdSchema -lTKSTEP -lTKSTEP209 -lTKSTEPAttr -lTKSTEPBase -lTKSTL -lTKTopAlgo -lTKV2d -lTKV3d -lTKXMesh -lTKXml -lTKXmlL -lTKXmlTObj -lTKXmlXCAF -lTKXSBase)
 
 target_link_libraries(worker ${ALL_LIBS})
 target_link_libraries(run-tests ${ALL_LIBS})


### PR DESCRIPTION
Describe how to alternately install dependencies w/homebrew Mac OS X pkg manager

If freetype has not been installed using macports and freetype is available in /usr/X11R6 use this version.

However if a user has installed freetype into /usr/local use this version in preference to any other.
