### PR TITLE
Added Ubuntu 12x specific notes to notes files

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ From within the cloned shapesmith repo:
     $ cd nodes/apps/worker/priv
     $ ./regen_build.sh
 
-If all the tests pass you should now have a usable worker process
+If all the tests pass you should now have a usable worker process. (Note: if the tests do not compile, and you are running Ubuntu 12x, see the notes about compiling gtest in INSTALL.ubuntu.md).
 
 ## Optional Installs
 
@@ -63,3 +63,19 @@ If all the tests pass, run shapesmith:
 Point your browser to
 
     $ http://localhost:8000 
+
+
+## Note: Use the local 'rebar' instance
+
+The latest rebar does not work with the one of the dependencies (erlang-bcrypt). So, even if you have rebar installed, be sure to use the rebar that comes with this project. This means, when the instructions below say:
+
+    $ ./rebar foo
+
+Do not forget the "./" in front of the 'rebar' command, this insures that you are running this program from the current directory. Whereas, running:
+
+    $ rebar foo
+
+will run rebar from wherever it is installed on your system...and if your version of rebar is recent, then rebar might not compile your project correctly (as is currently the case with erlang-bcrypt).
+
+See: 
+    https://github.com/smarkets/erlang-bcrypt/pull/6

--- a/INSTALL.ubuntu.md
+++ b/INSTALL.ubuntu.md
@@ -18,3 +18,25 @@ For older version, you can install JSON Spirit from source:
     $ cmake ..
     $ make
     $ sudo make install
+
+## Ubuntu 12.x specific notes
+
+The google test libraries, 'gtest', no longer install the binaries by default.
+
+So, if you receive the following error when building, then you need to compile the gtest libraries locally.
+
+    CMake Error at
+    /usr/share/cmake-2.8/Modules/FindPackageHandleStandardArgs.cmake:91
+    (MESSAGE):
+        Could NOT find GTest (missing: GTEST_LIBRARY GTEST_MAIN_LIBRARY) 
+
+This thread describes the issue: 
+
+    http://askubuntu.com/questions/145887/why-no-library-files-installed-for-google-test-on-12-04
+
+gtest build instructions:
+
+    cd /usr/src/gtest
+    sudo cmake .
+    sudo make
+    sudo mv libg* /usr/lib/


### PR DESCRIPTION
1. Ubuntu 12x packages do not compile gtest, you have to do this yourself.
2. Recent versions of rebar do not compile erlang-bcrypt
